### PR TITLE
Alphabetize skills on learn page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+_site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/js/learn.js
+++ b/js/learn.js
@@ -19,58 +19,69 @@ var learn = (function (learn) {
     $('#main').toggle();
   }
 
+  function _alphabetize(a, b) {
+    // Pass to Array.sort() method as a comparison function for categories, based on the 'name' property.
+    return (a.name < b.name) ? -1 : ((a.name > b.name) ? 1 : 0);
+  }
+
   function _main(response){
     $('#loading').toggle();
     $('#main').toggle();
-    categories = response.objects;
+    allCategories = response.objects.sort(_alphabetize);
+
+    for (var i in allCategories) {
+      if (allCategories[i].state == "published") {
+        categories.push(allCategories[i])
+      }
+    }
+
     $(categories).each(function(i){
       if (config.debug) console.log(categories[i].name);
-      if (categories[i].state == "published"){
-        if (i % 2 == 0){
-          $("#category-left").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')
-        } else {
-          $("#category-right").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')
+
+      if (i % 2 === 0) {
+        $("#category-left").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')
+      } else {
+        $("#category-right").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')
+      }
+
+      var html = '<div class="category col-md-offset-1 col-lg-offset-1 col-lg-10"> \
+      <a name="'+categories[i].id+'"></a> \
+      <h2 class="orange">'+categories[i].name+'</h2> \
+      <p>'+categories[i].description+'</p> \
+      <div class="row">';
+
+      var services = categories[i].services;
+      $.each(services, function(x){
+        if (services[x].state == "published"){
+          console.log("SERVICE STATE: "+services[x].state);
+          // TODO: WHEN MORE THAN 4, ADD A NEW ROW
+          // if (x % 4 == 0) {
+          //   html += '</div><div class="row">';
+          // }
+            html += '<div class="col-sm-3 col-md-3 col-lg-3"> \
+                      <div class="service-header"> \
+                        <img src="'+services[x].icon+'" class="left"> \
+                        <a class="service-link" href="service.html?'+services[x].id+'">'+services[x].name+'</a><br/> \
+                      </div> \
+                      <br/> \
+                      <p class="service-description">'+services[x].short_description+'</p> \
+                    </div>';
         }
-
-        var html = '<div class="category col-md-offset-1 col-lg-offset-1 col-lg-10"> \
-        <a name="'+categories[i].id+'"></a> \
-        <h2 class="orange">'+categories[i].name+'</h2> \
-        <p>'+categories[i].description+'</p> \
-        <div class="row">';
-
-        var services = categories[i].services;
-        $.each(services, function(x){
-          if (services[x].state == "published"){
-            console.log("SERVICE STATE: "+services[x].state);
-            // TODO: WHEN MORE THAN 4, ADD A NEW ROW
-            // if (x % 4 == 0) {
-            //   html += '</div><div class="row">';
-            // }
-              html += '<div class="col-sm-3 col-md-3 col-lg-3"> \
-                        <div class="service-header"> \
-                          <img src="'+services[x].icon+'" class="left"> \
-                          <a class="service-link" href="service.html?'+services[x].id+'">'+services[x].name+'</a><br/> \
-                        </div> \
-                        <br/> \
-                        <p class="service-description">'+services[x].short_description+'</p> \
-                      </div>';
-          }
-        })
-        html += '<div id="teach-callout" class="col-xs-10 col-sm-3 col-md-3 col-lg-3"> \
-                  <div class="row"> \
-                    <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3"> \
-                      <img src="img/teach_gray.png"> \
-                    </div> \
-                    <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9"> \
-                      <p>Already '+categories[i].name+'?</p><br/> \
-                      <p><a href="teach.html">Help teach other business owners!</a></p> \
-                    </div> \
+      })
+      html += '<div id="teach-callout" class="col-xs-10 col-sm-3 col-md-3 col-lg-3"> \
+                <div class="row"> \
+                  <div class="col-xs-3 col-sm-3 col-md-3 col-lg-3"> \
+                    <img src="img/teach_gray.png"> \
+                  </div> \
+                  <div class="col-xs-9 col-sm-9 col-md-9 col-lg-9"> \
+                    <p>Already '+categories[i].name+'?</p><br/> \
+                    <p><a href="teach.html">Help teach other business owners!</a></p> \
                   </div> \
                 </div> \
               </div> \
             </div> \
-            <hr class="col-lg-offset-1 col-lg-10">';
-      }
+          </div> \
+          <hr class="col-lg-offset-1 col-lg-10">';
 
       $("#categories").append(html);
     })

--- a/js/learn.js
+++ b/js/learn.js
@@ -38,7 +38,7 @@ var learn = (function (learn) {
     $(categories).each(function(i){
       if (config.debug) console.log(categories[i].name);
 
-      if (i % 2 === 0) {
+      if (i < (categories.length / 2)) {
         $("#category-left").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')
       } else {
         $("#category-right").append('<a href="#'+categories[i].id+'">'+categories[i].name+'</p>')


### PR DESCRIPTION
See https://github.com/codeforamerica/bizfriendly-web/issues/110

Categories (skills) are alphabetized with a sort function. [Details at MDN.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FArray%2Fsort)

Also, determining what column a skill should be listed in based on its index in the array was unreliable, because there are unpublished skills in it and that created holes in the column. I fixed this by creating an array of only published skills first.
