### PR TITLE
Fix sign in color for successful sign-in actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+_site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/js/BfUser.js
+++ b/js/BfUser.js
@@ -188,7 +188,7 @@ var BfUser = (function (BfUser)  {
     $('#bfSignUp').attr("disabled", "disabled");
 
     _updatePage();
-    $('#alert h2').addClass('alert alert-success').html("Great. You're all signed up.");
+    $('#alert h2').removeClass('alert-danger').addClass('alert alert-success').html("Great. You're all signed up.");
   };
 
   //Set User state based on sign in response
@@ -210,7 +210,7 @@ var BfUser = (function (BfUser)  {
     $('#bfSignIn').attr("disabled", "disabled");
 
     _updatePage();
-    $('#alert h2').addClass('alert alert-success').html("Great. You're signed in. <a href='signin.html?signout=true'>Sign in under a different account?</a>");
+    $('#alert h2').removeClass('alert-danger').addClass('alert alert-success').html("Great. You're signed in. <a href='signin.html?signout=true'>Sign in under a different account?</a>");
   };
 
   // Update page to reflect user state


### PR DESCRIPTION
See https://github.com/codeforamerica/bizfriendly-web/issues/152

I don't have valid credentials to test this, but it should work - like other actions already in BFuser.js, whenever the alert-success class is added to the message box, jQuery should also remove the alert-danger class - because once added, it'll override alert-success.

P.S. apologies for the commits with dev environment files - I think they're useful to have, but I'm not good enough with the git to figure out how to cherry pick commits yet.
