### PR TITLE
Hack the header to make sign-in links not completely broken on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+_site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="navbar navbar-static-top row">
     <a class="navbar-brand" href="/"><img src="img/BizFriendly-logo.png"></a>
-    <div id="signinlinks" class="pull-right">
+    <div id="signinlinks" class="col-sm-8 col-md-9 col-lg-9">
         <a id="signInLink" href="signin.html">Sign In</a>
         <a id="signUpLink" href="signup.html" >Sign Up</a>
         <a id="bfUserName" href="profile.html"></a>
@@ -11,8 +11,4 @@
         <li class="col-sm-2 col-md-2 col-lg-2 col-sm-offset-1 col-md-offset-1 col-lg-offset-1"><a href="teach.html">Teach</a></li>
         <li class="col-sm-2 col-md-2 col-lg-2 col-sm-offset-1 col-md-offset-1 col-lg-offset-1"><a href="connect.html">Connect</a></li>
     </ul>
-    <div class="visible-xs"/>
-    <br/>
-    <br/>
-    </div>
 </header>

--- a/css/main.css
+++ b/css/main.css
@@ -217,7 +217,12 @@ th {
 
 
 /*POSITION */
+header {
+	height: 180px;
+}
+
 .navbar {
+	position: relative;
 	margin-bottom: 0;
 }
 
@@ -441,10 +446,16 @@ ul{
 }
 
 .nav {
-	margin-top: 56px;
-	margin-left: -31px;
+	position: absolute;
+	top: 75px;
+	left: 199px;
 	height: 33px;
 	background-color: #585b5b;
+}
+
+.navbar-brand {
+	position: absolute;
+	left: 0;
 }
 
 .navbar-nav li a {
@@ -474,9 +485,13 @@ ul{
 }
 
 #signinlinks {
-	position: relative;
-	top: 50px;
-	left: -100px;
+	text-align: right;
+	margin-top: 45px;
+	margin-left: 200px;
+}
+
+#signinlinks a {
+	white-space: nowrap;
 }
 
 #main-text {


### PR DESCRIPTION
See https://github.com/codeforamerica/bizfriendly-web/issues/138

I don't think it's an ideal solution. But at least it looks okay?

![image](https://f.cloud.github.com/assets/2553268/1882289/07c4c2ee-7974-11e3-8ea0-7b355540a753.png)
