### PR TITLE
Scale service image to fit the allotted space on the page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.bundle/
+_site/
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/css/main.css
+++ b/css/main.css
@@ -87,9 +87,9 @@ a {
 
 #service-media {
 	position: relative;
-    padding-bottom: 56.25%; /* 16/9 ratio */
-    height: 0;
-    overflow: hidden;
+  padding-bottom: 56.25%; /* 16/9 ratio */
+  height: 0;
+  overflow: hidden;
 }
 
 #service-media iframe,
@@ -100,6 +100,10 @@ a {
     left: 0;
     width: 100%;
     height: 100%;
+}
+
+#service-media img {
+	width: 100%;
 }
 
 .service-link {


### PR DESCRIPTION
See https://github.com/codeforamerica/bizfriendly-web/issues/155

Works for `img` tags only, not `iframe` or others.
