### PR TITLE
[Fix] Text Overlap Issue on Connect Page (Issue #236)

### DIFF
--- a/js/connect.js
+++ b/js/connect.js
@@ -114,11 +114,11 @@ var connect = (function (connect) {
     $.each(userLessonCounts, function(i,userLessonCount){
       if (i < 5){ // Top five learners
         html += '<br/><div class="row">';
-        html += '<div class="col-sm-3 col-md-3 col-lg-3 center">';
+        html += '<div class="col-sm-4 col-md-5 col-lg-3 center">';
         html += '<p class="orange bold">'+userLessonCount.count;
         html += '<br/>lessons</p>';
         html += '</div>';
-        html += '<div class="col-sm-9 col-md-9 col-lg-9">';
+        html += '<div class="col-sm-8 col-md-7 col-lg-9">';
         html += '<a href="profile.html?'+userLessonCount.user.id+'">'+userLessonCount.user.name+'</a><br/>';
         if (userLessonCount.user.business_name) {
           html += userLessonCount.user.business_name;


### PR DESCRIPTION
**Issue**
- Text under the "Top Learners" column on the connect page would overlap when the window is compressed. Issue #236.

**Solution**
- Modified child elements of the top learners in the connect page element to use different column classes based on screen size.
