### PR TITLE
[Fix] Fixes broken link in new category page (Issue #227)

### DIFF
--- a/new-category.html
+++ b/new-category.html
@@ -15,7 +15,7 @@ js: new-category
     <div id="subheader" class="row">
         <div class="col-sm-offset-1">
             <h1>Use the form below to add a skill category to BizFriend.ly</h1>
-            <p>If you're new to creating content, we recommend checking out the <a href="#">Teaching Guide</a> before you begin.</p>
+            <p>If you're new to creating content, we recommend checking out the <a href="teaching-guide.html">Teaching Guide</a> before you begin.</p>
         </div>
         <div class="alert alert-info login-required col-sm-offset-1">
             You'll need to create a BizFriend.ly account before you can create a lesson. <a href="signup.html">Sign up</a> then come back here.


### PR DESCRIPTION
**Issue**
The "Teaching Guide" link had an empty `href` value. Issue #227.

**Solution**
Added a `href` value to `teaching-guide.html`
