### PR TITLE
Fix bug in Safari on teach.html #253

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 BizFriend.ly Web Site
 =========
 
-http://BizFriend.ly teaches you how to use the internet to increase your quality of life, be more effecient at work, and perhaps even how to be a better citizen.
+http://BizFriend.ly teaches you how to use the internet to increase your quality of life, be more efficient at work, and perhaps even how to be a better citizen.
 
 ## <a name="about"></a>About
 This is the main website for the BizFriend.ly service. It is powered by the [BizFriend.ly API](http://github.com/codeforamerica/bizfriendly-api)

--- a/css/main.css
+++ b/css/main.css
@@ -460,7 +460,7 @@ h2 {
 	line-height: 20px;
 }
 
-h3 { 
+h3 {
 	font-family: 'Open Sans', sans-serif;
 	font-size: 14px;
 	font-weight: 700;
@@ -544,11 +544,11 @@ ul{
 	padding-bottom: 15px;
 }
 
-/* 
- * 
- * 	BUTTONS 
- */ 
-.btn { 
+/*
+ *
+ * 	BUTTONS
+ */
+.btn {
 	border-radius:5px;
 	font-family: MuseoSlab;
 	text-align: center;
@@ -1175,13 +1175,6 @@ section .btn{
 	text-align: center;
 }
 
-.center-btn {
-	position: absolute;
-	bottom: 0px;
-	left: 50%;
-	transform: translate(-50%, 0);
-}
-
 #connect #left-column {
 	min-width:330px;
 }
@@ -1332,7 +1325,7 @@ section .btn{
 	background-color: #FFC9AE;
 	border-radius: 15px;
 	padding-top: 16px;
-  padding-bottom: 50px;
+  padding-bottom: 16px;
 	min-height: 425px;
 	margin-bottom: 15px;
 }
@@ -1341,13 +1334,14 @@ section .btn{
 	background-color: #C7E4EE;
 	border-radius: 15px;
   padding-top:16px;
-	padding-bottom: 50px;
+	padding-bottom: 16px;
 	min-height: 225px;
 	margin-bottom: 15px;
 }
 
 .teach-top a, .teach-bottom a {
 	margin: 15px auto;
+  white-space: normal;
 }
 
 .teach-top, .teach-bottom {

--- a/teach.html
+++ b/teach.html
@@ -35,7 +35,7 @@ title: teach
                 <li>A lesson name</li>
                 <li>Time to write and iterate on your lesson</li>
             </ul>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="lesson-builder.html" type="button" class="btn btn-primary">Create Lesson</a>
             </div>
         </div>
@@ -55,7 +55,7 @@ title: teach
                 <li>Icon for the service</li>
                 <li>Screenshot of the service or a testimonial video</li>
             </ul>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="new-service.html" type="button" class="btn btn-primary">Add Service</a>
             </div>
         </div>
@@ -72,7 +72,7 @@ title: teach
                 <li>A skill name</li>
                 <li>A brief description of the skill and why it’s valuable to business owners</li>
             </ul>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="new-category.html" type="button" class="btn btn-primary">New Skill</a>
             </div>
         </div>
@@ -84,7 +84,7 @@ title: teach
             <p>
                 Before you get started, we recommend reading the Teaching Guide. It gives you all of the basics to creating great lessons and new content for BizFriend.ly!
             </p>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="teaching-guide.html" type="button" class="btn btn-default">Open Teaching Guide</a>
             </div>
         </div>
@@ -92,7 +92,7 @@ title: teach
             <h2>Request Content</h2>
             <hr/>
             <p>Not ready to build new content for BizFriend.ly? No problem! You can request that another teacher creates a lesson, skill, or category. What do you want to learn?</p>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="request.html" type="button" class="btn btn-default">Make a Request</a>
             </div>
         </div>
@@ -100,7 +100,7 @@ title: teach
             <h2>See Requests</h2>
             <hr/>
             <p>Not sure what you want to teach? See the requests made by fellow learners.</p>
-            <div class="center center-btn">
+            <div class="center">
                 <a href="content-requests.html" type="button" class="btn btn-default">See Requests</a>
             </div>
         </div>


### PR DESCRIPTION
This fixes issue #253. Safari was confused by using relative positioning with the center class and absolute positioning with the center-btn class. We can fix by removing the center-btn class altogether and fixing the spacing in the teach-top and teach-bottom classes. Changed white-space to normal on the buttons because otherwise the text won't wrap and the button will spill out of the box at the skinniest column size.

Tested in IE11 and latest Chrome, Safari, and Firefox on Mac.
